### PR TITLE
Use query params in cache key

### DIFF
--- a/lib/tesla_cache.ex
+++ b/lib/tesla_cache.ex
@@ -21,7 +21,7 @@ defmodule Tesla.Middleware.Cache do
   end
 
   defp get_from_cache(env, :get) do
-    {Cachex.get!(:tesla_cache_cachex, env.url), env}
+    {Cachex.get!(:tesla_cache_cachex, cache_key(env)), env}
   end
 
   defp get_from_cache(env, _), do: {nil, env}
@@ -36,10 +36,12 @@ defmodule Tesla.Middleware.Cache do
   end
 
   defp set_to_cache({:miss, %Tesla.Env{status: status} = env}, ttl) when status == 200 do
-    Cachex.set(:tesla_cache_cachex, env.url, env, ttl: ttl)
+    Cachex.set(:tesla_cache_cachex, cache_key(env), env, ttl: ttl)
     {:ok, env}
   end
 
   defp set_to_cache({:miss, env}, _ttl), do: {:ok, env}
   defp set_to_cache({:hit, env}, _ttl), do: {:ok, env}
+
+  defp cache_key(%Tesla.Env{url: url, query: query}), do: Tesla.build_url(url, query)
 end

--- a/lib/tesla_cache.ex
+++ b/lib/tesla_cache.ex
@@ -37,9 +37,9 @@ defmodule Tesla.Middleware.Cache do
 
   defp set_to_cache({:miss, %Tesla.Env{status: status} = env}, ttl) when status == 200 do
     Cachex.set(:tesla_cache_cachex, env.url, env, ttl: ttl)
-    env
+    {:ok, env}
   end
 
-  defp set_to_cache({:miss, env}, _ttl), do: env
-  defp set_to_cache({:hit, env}, _ttl), do: env
+  defp set_to_cache({:miss, env}, _ttl), do: {:ok, env}
+  defp set_to_cache({:hit, env}, _ttl), do: {:ok, env}
 end

--- a/test/tesla_cache_test.exs
+++ b/test/tesla_cache_test.exs
@@ -49,7 +49,12 @@ defmodule Tesla.Middleware.CacheXTest do
 
   describe "when response status code is 200" do
     setup do
-      [res: Client.get("/200_OK")]
+      {:ok, res} = Client.get("/200_OK")
+      [res: res]
+    end
+
+    test "should return the body as OK", context do
+      assert context[:res].body == "OK"
     end
 
     test "should do the real request in the first call" do
@@ -68,7 +73,8 @@ defmodule Tesla.Middleware.CacheXTest do
     end
 
     test "second request should have the same response value as the first one", context do
-      assert context[:res] == Client.get("/200_OK")
+      {:ok, res2} = Client.get("/200_OK")
+      assert context[:res] == res2
     end
   end
 


### PR DESCRIPTION
This considers the query params when caching so that http://foo.com?q=1 and http://foo.com?q=2 do not return the same result from the cache.

To fix this I also had to apply the changes in https://github.com/emerleite/tesla_cache/pull/9 (which are included in this PR, plus some tests for this)